### PR TITLE
Changes to allow building with arduino 1.8.12

### DIFF
--- a/5x3/font.c
+++ b/5x3/font.c
@@ -1,6 +1,6 @@
 #include "font.h"
 
-prog_uint8_t font5x3[][3] = {
+const glyph5x3 font5x3[] PROGMEM = {
 	{0x00,0x00,0x00}, // ' '
 	{0x00,0x1D,0x00}, // '!'
 	{0x18,0x00,0x18}, // '"'
@@ -98,3 +98,4 @@ prog_uint8_t font5x3[][3] = {
 	{0x08,0x18,0x10}, // '~'
 };
 
+const int font5x3len = sizeof(font5x3)/sizeof(*font5x3);

--- a/5x3/font.h
+++ b/5x3/font.h
@@ -5,11 +5,11 @@
 
 #ifdef __AVR__
 #include <avr/pgmspace.h>
-typedef prog_uint8_t glyph5x3[3];
 #else
 #define PROGMEM
-typedef unsigned char glyph5x3[3];
 #endif
+
+typedef unsigned char glyph5x3[3];
 
 extern const glyph5x3 font5x3[];
 extern const int font5x3len;

--- a/5x3/font.h
+++ b/5x3/font.h
@@ -1,12 +1,17 @@
 #ifndef FONT_H
 #define FONT_H
 
+// The ardiono AVR core will try to use the pgmspace stuff to save RAM
+
 #ifdef __AVR__
 #include <avr/pgmspace.h>
+typedef prog_uint8_t glyph5x3[3];
 #else
-typedef const unsigned char prog_uint8_t;
+#define PROGMEM
+typedef unsigned char glyph5x3[3];
 #endif
 
-extern prog_uint8_t font5x3[][3];
+extern const glyph5x3 font5x3[];
+extern const int font5x3len;
 
 #endif //FONT_H

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#PixelFonts
+# PixelFonts
 Small Fonts for embedded systems
 
 Dirt simple C array

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+#PixelFonts
+Small Fonts for embedded systems
+
+Dirt simple C array


### PR DESCRIPTION
Type system changes needed for new GCC compiler
PROGMEM is a variable modifier not a type modifier and GCC is picky about it.
So this change makes a type glyph5x3 of the unusual type of array 3 of unsigned char which is needed to get GCC to allow the PROGMEM to work.  Also, it's a neat type to have because you can use it in structures and other things to hold a glyph, i.e. a single character from the font.
Old type prog_uint8_t is obsolete.  Actually it looks like the whole pgmspace.h is going to be obsolete soon.  But in the meantime this builds and puts the font into flash not RAM!
Also made a length constant so the length of the font array can be coded from the compiler generated value and does not need to be guessed at.

Also added a simple README
